### PR TITLE
Rename to angular-netcore-starter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angular2-core-starter",
+  "name": "angular-netcore-starter",
   "version": "1.0.0",
   "scripts": {
     "start": "gulp build && gulp watch"


### PR DESCRIPTION
"Angular2" is no longer "Angular2" but rather just "Angular" (Angular 1.x is Angular.js).